### PR TITLE
Add support for flow control structures

### DIFF
--- a/__tests__/index.test.ts
+++ b/__tests__/index.test.ts
@@ -48,6 +48,31 @@ test
   );
 });
 
+test("format conditional block", async () => {
+  const code =
+`  <%= if foo %>
+test
+                  <%= link_to test do %> link <% end %>
+      <% end %>
+  <%= unless bar %>
+  test
+    <% end %>
+`;
+  const result = await prettier.format(code, { parser: "eruby-parse", plugins: [erubyParse] });
+  expect(result).toBe(
+`<%= if foo %>
+  test
+  <%= link_to test do %>
+    link
+  <% end %>
+<% end %>
+<%= unless bar %>
+  test
+<% end %>
+`,
+  );
+});
+
 test("support options", async () => {
   const code =
 `  <%= form_with test do %>

--- a/index.ts
+++ b/index.ts
@@ -98,7 +98,10 @@ class ErbElement {
 
   // duplicate code
   get isOpenTag() {
-    return /\s*do\s*(\|\s*.*\s*\|\s*)?%>/.test(this.#indentedContent(""));
+    const content = this.#indentedContent("")
+    const isIf = /\s(if|unless)\s/.test(this.#indentedContent(""));
+    const isBlock = /\s*do\s*(\|\s*.*\s*\|\s*)?%>/.test(this.#indentedContent(""));
+    return (isBlock || isIf);
   }
   get isCloseTag() {
     return /<%\s*end\s*%>/.test(this.#indentedContent(""));


### PR DESCRIPTION
Currently flow control structures are not handled and crash the plugin, this is re-using the same trick used on blocks, it will not handle conditionals used in element tags.